### PR TITLE
Automatic resizing of the exercise iframe

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,10 +24,14 @@ ACOSAPlus.addToHead = function(params, req, contentPackage) {
 ACOSAPlus.addToBody = function(params, req) {
 
   if (req.query.content !== 'ready') {
-    var fullUrl = req.protocol + '://' + req.get('host') + req.originalUrl + '&content=ready';
+    var hostUrl = req.protocol + '://' + req.get('host');
+    var fullUrl = hostUrl + req.originalUrl + '&content=ready';
     var width = req.query.width || 770;
     var height = req.query.height || 500;
-    params.bodyContent += '<iframe id="iframe" src="' + fullUrl + '" width="' + width + '" height="' + height + '" style="box-shadow: none; border: none;"></iframe>\n';
+    params.bodyContent += '<iframe class="acos-iframe" src="' + fullUrl + '" width="' + width + '" height="' + height + '" style="box-shadow: none; border: none;"></iframe>\n';
+    if (!req.query.noResizeIframe) {
+      params.bodyContent += '<script src="' + hostUrl + '/static/aplus/resizeiframe.js" type="text/javascript"></script>\n';
+    }
   } else {
     // This will be inside the previously created iframe
     params.bodyContent += '<input type="hidden" name="submission_url" value="' + req.query.submission_url + '">\n';

--- a/static/resizeiframe.js
+++ b/static/resizeiframe.js
@@ -1,0 +1,25 @@
+document.addEventListener("DOMContentLoaded", function() {
+  var acosAplusResizeIframe = function($, window, document, undefined) {
+    var exerciseWrapper = $('#exercise-page-content'); // A+ adds this around exercise content
+    var newWidth = Math.max(exerciseWrapper.width(), 500); // full width of the exercise area in the A+ page
+    var newHeight = Math.max($(window).height() * 0.8, 500); // 80% of viewport height
+    $('.acos-iframe').width(newWidth).height(newHeight);
+  };
+  
+  var init = function($, window, document) {
+    acosAplusResizeIframe($, window, document);
+    $(window).on('resize', function() {
+      acosAplusResizeIframe($, window, document);
+    });
+  };
+
+  if (typeof require === 'function') {
+    // in Moodle
+    require(["jquery"], function(jQuery) {
+      init(jQuery, window, document);
+    });
+  } else {
+    // in A+
+    init(jQuery, window, document);
+  }
+});

--- a/static/resizeiframe.js
+++ b/static/resizeiframe.js
@@ -14,12 +14,12 @@ document.addEventListener("DOMContentLoaded", function() {
   };
 
   if (typeof require === 'function') {
-    // in Moodle
+    // in a require.js environment, import jQuery
     require(["jquery"], function(jQuery) {
       init(jQuery, window, document);
     });
   } else {
-    // in A+
+    // in A+ (jQuery defined in the global namespace)
     init(jQuery, window, document);
   }
 });


### PR DESCRIPTION
Make the exercise iframe automatically resize itself so that it fits more nicely to the A+ exercise page (scales to the size of the window as well).

The frontend JS was written in a way that works for both A+ and the Moodle plugin (Astra).