### PR TITLE
Add support for A+ LTI

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,10 @@ ACOSAPlus.addToBody = function(params, req) {
     if (uid) {
       params.bodyContent += '<input type="hidden" name="uid" value="' + htmlencode(uid) + '">\n';
     }
+    var lti_launch_id = req.query.lti_launch_id;
+    if (lti_launch_id) {
+      params.bodyContent += '<input type="hidden" name="lti_launch_id" value="' + htmlencode(lti_launch_id) + '">\n';
+    }
   }
 
   return true;

--- a/static/events.js
+++ b/static/events.js
@@ -12,6 +12,10 @@
     if (uid) {
       protocolData.uid = uid;
     }
+    var lti_launch_id = $('input[name="lti_launch_id"]').attr('value');
+    if (lti_launch_id) {
+      payload.lti_launch_id = lti_launch_id;
+    }
 
     var target = window.location.pathname;
     if (target[target.length - 1] == '/') {


### PR DESCRIPTION
This fixes an issue with acos exercises in "A+ as LTI tool" contexts where A+ was unable to send points received from acos to the LTI platform.