### PR TITLE
Add lti_session_id parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,10 @@ ACOSAPlus.addToBody = function(params, req) {
     if (lti_launch_id) {
       params.bodyContent += '<input type="hidden" name="lti_launch_id" value="' + htmlencode(lti_launch_id) + '">\n';
     }
+    var lti_session_id = req.query.lti_session_id;
+    if (lti_session_id) {
+      params.bodyContent += '<input type="hidden" name="lti_session_id" value="' + htmlencode(lti_session_id) + '">\n';
+    }
   }
 
   return true;

--- a/static/events.js
+++ b/static/events.js
@@ -16,6 +16,10 @@
     if (lti_launch_id) {
       payload.lti_launch_id = lti_launch_id;
     }
+    var lti_session_id = $('input[name="lti_session_id"]').attr('value');
+    if (lti_session_id) {
+      payload.lti_session_id = lti_session_id;
+    }
 
     var target = window.location.pathname;
     if (target[target.length - 1] == '/') {


### PR DESCRIPTION
Added an lti_session_id parameter so points can be sent to Moodle via LTI 1.3 - see https://github.com/apluslms/a-plus/issues/1305 for further details.